### PR TITLE
cd: use self-hosted runner with Docker deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,53 +1,32 @@
-name: Deploy to Vercel
+name: Deploy
 
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
-
-env:
-  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
 jobs:
   deploy:
-    name: ${{ github.event_name == 'push' && 'Production Deploy' || 'Preview Deploy' }}
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
+    name: Build & Deploy Docker
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install Vercel CLI
-        run: npm install -g vercel@latest
-
-      - name: Pull Vercel environment
-        run: vercel pull --yes --environment=${{ github.event_name == 'push' && 'production' || 'preview' }} --token=${{ secrets.VERCEL_TOKEN }}
-
-      - name: Build project artifacts
-        run: vercel build ${{ github.event_name == 'push' && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }}
-
-      - name: Deploy to Vercel
-        id: deploy
+      - name: Build Docker image
         run: |
-          url=$(vercel deploy --prebuilt ${{ github.event_name == 'push' && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }})
-          echo "url=$url" >> $GITHUB_OUTPUT
+          docker build -t vortexfiles-www:latest -t vortexfiles-www:${{ github.sha }} .
 
-      - name: Comment preview URL on PR
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `🚀 Preview deployed to: ${{ steps.deploy.outputs.url }}`
-            })
+      - name: Stop and remove old container
+        run: |
+          docker stop vortexfiles-www || true
+          docker rm vortexfiles-www || true
+
+      - name: Start new container
+        run: |
+          docker run -d \
+            --name vortexfiles-www \
+            --restart unless-stopped \
+            -p 3000:3000 \
+            vortexfiles-www:latest
+
+      - name: Prune old images
+        run: docker image prune -f --filter "label=app=vortexfiles-www"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# ---- Build stage ----
+FROM node:22-alpine AS builder
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+# ---- Runtime stage ----
+FROM node:22-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PORT=3000
+
+# Copy only what's needed to run
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./package.json
+
+EXPOSE 3000
+
+CMD ["npm", "start"]


### PR DESCRIPTION
Replaces Vercel deployment with a self-hosted runner workflow that builds and runs the app in Docker on `pve1`.

**Changes:**
- Add `Dockerfile` (multi-stage, Node 22 Alpine)
- Update `deploy.yml`: runs on `[self-hosted, Linux, X64]`, builds image, rotates container on port 3000, prunes old images

No secrets required — runs directly on the server.